### PR TITLE
Syntax highlighter + Highlight

### DIFF
--- a/lib/renderer/example.js
+++ b/lib/renderer/example.js
@@ -15,11 +15,23 @@ module.exports = class Example extends Fragment {
     this.codeWrapper = this.dom.querySelector(".pimd-code")
     this.code = this.dom.querySelector("code")
     this.info = new InfoString(infoString)
-    this.code.textContent = this.content
     this.addLangClass()
     if (this.info.additionalInfo) {
       renderer.config.parseInfoString(this.info.additionalInfo, this)
     }
+    this.hooks.add("example:beforeRender", "highlight", () => {
+      const highlight =
+        this.renderer && this.renderer.config && this.renderer.config.highlight
+      let code = this.content
+      code = this.hooks.run("example:beforeHighlight", this, code)
+      if (highlight) {
+        code = highlight(code, this.info.lang)
+      } else {
+        this.code.textContent = code
+        code = this.code.innerHTML
+      }
+      this.code.innerHTML = this.hooks.run("example:afterHighlight", this, code)
+    })
   }
 
   addLangClass() {

--- a/plugins/html-injector/.npmignore
+++ b/plugins/html-injector/.npmignore
@@ -1,0 +1,1 @@
+plugins/ test/ test.js *.test.js .travis.yml .eslintrc lerna.json

--- a/plugins/html-injector/README.md
+++ b/plugins/html-injector/README.md
@@ -1,0 +1,105 @@
+# PIMD HTML injector plugin
+
+A base for other plugins to insert functionality into code examples.
+
+## Basic idea
+
+It is easy to find out in a source code where to insert HTML – for example
+highlight a word, add a tooltip, etc. After the source code got HTML-escaped and
+syntax highlighted, it is hard to find the right offsets.
+
+This plugin translates offsets from before to after syntax highlighting.
+
+## Example
+
+Imagine you want to format the `x` in the following example in italics:
+
+```html
+<p>Example</p>
+```
+
+First the code gets HTML escaped:
+
+```html
+&lt;p&gt;Example&lt;/p&gt;
+```
+
+Then you can insert the `<i>` and `</i>`:
+
+```html
+&lt;p&gt;E<i>x</i>ample&lt;/p&gt;
+```
+
+With syntax highlighting enabled, this simple example already gets quite
+complex:
+
+```html
+<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>p</span><span class="token punctuation">&gt;</span></span>E<i>x</i>ample<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>p</span><span class="token punctuation">&gt;</span></span>
+```
+
+## Usage
+
+With this plugin enabled, you only need to know the offset and what to insert:
+
+```javascript
+// Offsets before highlighting:
+// <p>Example</p>
+// 01234567890123
+example.insertAt(4, "<i>") // Before the `x`
+example.insertAt(5, "</i>") // After the `x`
+```
+
+This is best put into a `example:beforeRender` hook:
+
+```javascript
+const myPlugin = function(config) {
+  config.hooks.add("example:beforeRender", "my-plugin", function(example) {
+    example.insertAt(4, "<i>") // Before the `x`
+    example.insertAt(5, "</i>") // After the `x`
+  })
+}
+```
+
+This of course would format every 4th character of every code example in italic.
+A real live example would make use of more dynamic code:
+
+```javascript
+const myPlugin = function(config) {
+  config.hooks.add("example:beforeRender", "my-plugin", function(example) {
+    const offset = example.content.indexOf("x")
+    example.insertAt(offset, "<i>") // Before the `x`
+    example.insertAt(offset + 1, "</i>") // After the `x`
+  })
+}
+```
+
+To add this to specific examples only, use a _InfoStringParser:_
+
+```javascript
+const myPlugin = function(config) {
+  config.addInfoStringParser(/italicx/, function(match, rules) {
+    this.hooks.add("example:beforeRender", "my-plugin", function(example) {
+      const offset = example.content.indexOf("x")
+      example.insertAt(offset, "<i>") // Before the `x`
+      example.insertAt(offset + 1, "</i>") // After the `x`
+    })
+  })
+}
+```
+
+Back to Markdown, the plugin can be used as simple as:
+
+````markdown
+```html italicx
+<p>Example</p>
+```
+````
+
+---
+
+## Copyright
+
+Copyright 2018++ [Nico Hagenburger](https://www.hagenburger.net). See
+[MIT-LICENSE](MIT-LICENSE) for details. Get in touch with
+[@hagenburger](https://twitter.com/hagenburger) on Twitter or
+[open an issue](https://github.com/hagenburger/pimd/issues/new).

--- a/plugins/html-injector/index.js
+++ b/plugins/html-injector/index.js
@@ -1,0 +1,60 @@
+module.exports = function(config) {
+  config.hooks.add("example:init", "html-injector", example => {
+    example.insertions = []
+    example.insertAt = function(offset, html) {
+      example.insertions.push({
+        offset: offset,
+        html: html
+      })
+    }
+  })
+
+  config.hooks.add(
+    "example:afterHighlight",
+    "html-injector",
+    (example, code) => {
+      return processInsertions(code, example.insertions)
+    }
+  )
+}
+
+function processInsertions(code, insertions) {
+  insertions = insertions.sort((a, b) => a.offset > b.offset)
+  let codeWithHighlights = ""
+  let offset = 0
+  let nextPosition = insertions.shift()
+  let insideCharacter = false
+  let insideHtml = false
+
+  for (let i = 0; i <= code.length; i++) {
+    const character = code[i] || ""
+    if (character === "<") {
+      insideHtml = true
+      if (nextPosition && offset == nextPosition.offset) {
+        codeWithHighlights += nextPosition.html
+        nextPosition.html = ""
+      }
+    } else if (insideHtml && character === ">") {
+      insideHtml = false
+    } else if (!insideHtml) {
+      if (nextPosition && offset === nextPosition.offset) {
+        codeWithHighlights += nextPosition.html
+        nextPosition = insertions.shift()
+      }
+      if (character === "&") {
+        insideCharacter = true
+        if (nextPosition && offset == nextPosition.offset) {
+          codeWithHighlights += nextPosition.html
+          nextPosition.html = ""
+        }
+      } else if (insideCharacter && character === ";") {
+        insideCharacter = false
+        offset++
+      } else if (!insideCharacter) {
+        offset++
+      }
+    }
+    codeWithHighlights += character
+  }
+  return codeWithHighlights
+}

--- a/plugins/html-injector/package.json
+++ b/plugins/html-injector/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@pimd/html-injector-plugin",
+  "version": "0.1.0",
+  "description": "Helper for injecting HTML into syntax-highlighted examples",
+  "main": "index.js",
+  "author": "Nico Hagenburger <nico@hagenburger.net> (https://twitter.com/hagenburger)",
+  "keywords": [
+    "markdown",
+    "pimd-plugin"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "license": "MIT",
+  "devDependencies": {
+    "pimd": "^0.1.0"
+  }
+}

--- a/plugins/html-injector/test.js
+++ b/plugins/html-injector/test.js
@@ -1,0 +1,31 @@
+const { Document } = require("../..")
+const plugin = require(".")
+const Config = require("../../lib/config")
+
+describe("HTML injector", () => {
+  it("should insert HTML at specific offsets", () => {
+    const input = unindent`
+      ~~~ html
+      <p>Example</p>
+      ~~~
+    `
+    const config = new Config()
+    config.highlight = () => "<b>&lt;p&gt;</b>Example&lt;/p&gt;"
+    const doc = new Document(input, config)
+    doc.config.use(plugin)
+    doc.hooks.add("example:beforeRender", "test", example => {
+      // Offsets before highlighting:
+      // <p>Example</p>
+      // 01234567890123
+      example.insertAt(5, "</i>")
+      example.insertAt(4, "<i>")
+    })
+    const html = doc.render()
+    expect(html)
+      .to.have.selector(".pimd-example code")
+      .with.innerHTML.to.equal("<b>&lt;p&gt;</b>E<i>x</i>ample&lt;/p&gt;")
+    // Offsets after highlighting:
+    // <b>&lt;p&gt;</b>E<i>x</i>ample&lt;/p&gt;
+    // ...0___12___....3...4....567890___123___
+  })
+})

--- a/test/renderer/example.test.js
+++ b/test/renderer/example.test.js
@@ -1,4 +1,5 @@
 const Example = require("../../lib/renderer/example")
+const Config = require("../../lib/config")
 
 describe("Rendering of example blocks", () => {
   it("should render", () => {
@@ -18,6 +19,18 @@ describe("Rendering of example blocks", () => {
     expect(html)
       .to.have.selector("code")
       .with.innerHTML.to.equal("&lt;p&gt;My code&lt;/p&gt;")
+  })
+
+  it("should highlight code", () => {
+    const config = new Config()
+    // A very basic syntax highlighter that highlights true/false only:
+    config.highlight = (code, lang) =>
+      code.replace(/(true|false)/g, "<b>$1</b>")
+    const code = new Example({ config: config }, {}, "if (true) return", "text")
+    const html = code.render()
+    expect(html)
+      .to.have.selector("code")
+      .with.innerHTML.to.equal("if (<b>true</b>) return")
   })
 
   it("should render with class names", () => {


### PR DESCRIPTION
This is basically working but very open for better naming suggestions. Especially “highlighter extras” is not self-explanatory.

I put both features into one pull request to provide a better understanding how the “highlighter extras” will be used.