### PR TITLE
Introduce info string commands

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -113,8 +113,8 @@ module.exports = class Config {
       if (infoString === infoStringBefore) {
         const spacePosition = infoString.indexOf(" ")
         if (spacePosition !== -1) {
-          const unkown = infoString.substr(0, spacePosition)
-          console.warn(`Unkown part in info string found: ${unkown}.`)
+          const unknown = infoString.substr(0, spacePosition)
+          console.warn(`Unknown part in info string found: ${unknown}.`)
           infoString = infoString.substr(infoString.indexOf(" ") + 1)
           keepGoing = true
         }

--- a/lib/config.js
+++ b/lib/config.js
@@ -9,8 +9,16 @@ module.exports = class Config {
     this.markdown.options.langPrefix = "lang-"
     this.Renderer = Renderer
     this.commands = {}
+    this.infoStringCommands = {}
     this.infoStringParsers = []
     this.loadDefaultCommands()
+    this.datatypes = {
+      regexp: "(\\/(?:[^\\/\\\\]*(?:\\\\.[^\\/\\\\]*)*)\\/[gmiuy]*)",
+      string: '"([^"\\\\]*(?:\\\\.[^"\\\\]*)*)"',
+      number: "(-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?)",
+      boolean: "(true|false)",
+      null: "(null)"
+    }
   }
 
   get hooks() {
@@ -32,12 +40,69 @@ module.exports = class Config {
     this.infoStringParsers.push({ regexp: regexp, func: func })
   }
 
+  addInfoStringCommand(name, options = {}, func) {
+    if (typeof options === "function") {
+      func = options
+      options = {}
+    }
+    let regexpString = `^\\+${name}`
+    let parameters
+    if (options.types) {
+      parameters =
+        "(" + options.types.map(type => this.datatypes[type]).join("|") + ")"
+      if (options.multiple) {
+        parameters += `((?:,${parameters})*)`
+      }
+      regexpString += "=(" + parameters + ")"
+    }
+    const regexp = new RegExp(regexpString, "g")
+
+    const getArguments = argumentsString => {
+      const regexp = new RegExp(parameters)
+      const currentArgument = argumentsString.match(regexp)[1]
+      const moreArguments = argumentsString.substr(currentArgument.length + 1)
+      const argumentsArray = []
+      options.types.forEach(type => {
+        if (currentArgument.match(new RegExp(`^${this.datatypes[type]}$`))) {
+          switch (type) {
+            case "regexp":
+              argumentsArray.push(
+                new RegExp(
+                  ...currentArgument.match(/^\/(.*?)\/([gmiuy]*)$/).slice(1)
+                )
+              )
+              break
+            default:
+              argumentsArray.push(JSON.parse(currentArgument))
+          }
+        }
+      })
+      if (moreArguments) {
+        argumentsArray.push(...getArguments(moreArguments))
+      }
+      return argumentsArray
+    }
+
+    this.infoStringParsers.push({
+      regexp: regexp,
+      func: function(...matches) {
+        let argumentsString = matches[1]
+        let argumentsArray = []
+        if (options.types) {
+          argumentsArray.push(...getArguments(argumentsString))
+        }
+        func.call(this, ...argumentsArray)
+      }
+    })
+  }
+
   parseInfoString(infoString, target) {
     if (!infoString) return
     let keepGoing = true
     while (infoString.length && keepGoing) {
       keepGoing = false
       infoString = infoString.trimLeft()
+      let infoStringBefore = infoString
       this.infoStringParsers.forEach(parser => {
         infoString = infoString.replace(parser.regexp, (...matches) => {
           keepGoing = true
@@ -45,6 +110,15 @@ module.exports = class Config {
           return ""
         })
       })
+      if (infoString === infoStringBefore) {
+        const spacePosition = infoString.indexOf(" ")
+        if (spacePosition !== -1) {
+          const unkown = infoString.substr(0, spacePosition)
+          console.warn(`Unkown part in info string found: ${unkown}.`)
+          infoString = infoString.substr(infoString.indexOf(" ") + 1)
+          keepGoing = true
+        }
+      }
     }
   }
 }

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -29,6 +29,101 @@ describe("Info strings", () => {
   })
 })
 
+describe("Info string commands", () => {
+  it("should add commands to info strings", () => {
+    const infoString = "xx +test4 xx"
+    const config = new Config()
+    config.addInfoStringCommand("test4", function(match) {
+      this.element.id = "id4"
+    })
+    const fragment = new Fragment()
+
+    config.parseInfoString(infoString, fragment)
+    expect(fragment.render()).to.have.selector('div[id="id4"]')
+  })
+
+  it("should add commands to info strings with regexp", () => {
+    const infoString = "xx +test5=/ab\\/c/g xx"
+    const config = new Config()
+    const func = sinon.spy()
+    config.addInfoStringCommand("test5", { types: ["regexp"] }, func)
+    const fragment = new Fragment()
+
+    config.parseInfoString(infoString, fragment)
+    expect(func).to.have.been.calledWith(/ab\/c/g)
+  })
+
+  it("should add commands to info strings with double quote string", () => {
+    const infoString = 'xx +test7="ab\\"c" xx'
+    const config = new Config()
+    const func = sinon.spy()
+    config.addInfoStringCommand("test7", { types: ["string"] }, func)
+    const fragment = new Fragment()
+
+    config.parseInfoString(infoString, fragment)
+    expect(func).to.have.been.calledWith('ab"c')
+  })
+
+  it("should add commands to info strings with number", () => {
+    const infoString = "xx +test9=-1234.5 xx"
+    const config = new Config()
+    const func = sinon.spy()
+    config.addInfoStringCommand("test9", { types: ["number"] }, func)
+    const fragment = new Fragment()
+
+    config.parseInfoString(infoString, fragment)
+    expect(func).to.have.been.calledWith(-1234.5)
+  })
+
+  it("should add commands to info strings with true", () => {
+    const infoString = "xx +test10=true xx"
+    const config = new Config()
+    const func = sinon.spy()
+    config.addInfoStringCommand("test10", { types: ["boolean"] }, func)
+    const fragment = new Fragment()
+
+    config.parseInfoString(infoString, fragment)
+    expect(func).to.have.been.calledWith(true)
+  })
+
+  it("should add commands to info strings with false", () => {
+    const infoString = "xx +test11=false xx"
+    const config = new Config()
+    const func = sinon.spy()
+    config.addInfoStringCommand("test11", { types: ["boolean"] }, func)
+    const fragment = new Fragment()
+
+    config.parseInfoString(infoString, fragment)
+    expect(func).to.have.been.calledWith(false)
+  })
+
+  it("should add commands to info strings with null", () => {
+    const infoString = "xx +test12=null xx"
+    const config = new Config()
+    const func = sinon.spy()
+    config.addInfoStringCommand("test12", { types: ["null"] }, func)
+    const fragment = new Fragment()
+
+    config.parseInfoString(infoString, fragment)
+    expect(func).to.have.been.calledWith(null)
+  })
+
+  it("should add commands to info strings with multiple values", () => {
+    const infoString = "xx +test13=23,/a,b,c/gi,true xx"
+    const config = new Config()
+    const func = sinon.spy()
+    config.addInfoStringCommand(
+      "test13",
+      { types: ["boolean", "number", "regexp"], multiple: true },
+      func
+    )
+    const fragment = new Fragment()
+
+    config.parseInfoString(infoString, fragment)
+    expect(func).to.have.been.calledWith(23, /a,b,c/gi, true)
+  })
+})
+
 describe("Pluings", () => {
   it("should load plugins", () => {
     const testFunction = function(pi) {


### PR DESCRIPTION
This prepares an API to create #19, #18, and #32. All those features will have very complex regular expressions and escaping. Therefore an API preparing those regular expressions and testing them centrally makes sense.

````markdown
``` +commandname
````

````markdown
``` +commandname=parameter
````

````markdown
``` +commandname=parameter1,parameter2,parameter3
````

Every command in info strings consists out of:

1. `+`
2. Name of the command
3. `=` (optional)
4. A parameter (`regexp`, `string`, `number`, `boolean`, or `null`; optional)
5. more paraters (comma-separated; optional)

Examples: See #19, #18, and #32
