### PR TITLE
Add missing second argument

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -38,7 +38,7 @@ module.exports = class Document {
 
   tokenize() {
     this.markdown.renderer = new this.config.Renderer(this)
-    this.tokens = this.markdown.parse(this.source)
+    this.tokens = this.markdown.parse(this.source, {})
 
     this.tokens.forEach((token, i) => {
       if (token.type === "heading_open") {


### PR DESCRIPTION
While parsing more complex Markdown code with link references,
Markdown-IT will fail if the `env` parameter isn’t set.