### PR TITLE
Render inline HTML properly

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -108,25 +108,38 @@ module.exports = class Renderer extends MarkdownItRenderer {
     let rules = this.rules
     const stack = []
 
+    const openTag = html => {
+      const nextNode = JSDOM.fragment(html).firstChild
+      if (nextNode) {
+        stack.push(this.currentNode)
+        this.currentNode.appendChild(nextNode)
+        this.currentNode = nextNode
+      }
+    }
+
+    const closeTag = () => {
+      this.currentNode = stack.pop()
+    }
+
     for (i = 0, len = tokens.length; i < len; i++) {
       let token = tokens[i]
       let type = token.type
       let hidden = token.hidden
 
       if (type.match(/_open$/) && !hidden) {
-        stack.push(this.currentNode)
-        const nextNodeHTML = this.renderToken(tokens, i, options, env)
-        const nextNode = JSDOM.fragment(nextNodeHTML).firstChild
-        if (nextNode) {
-          this.currentNode.appendChild(nextNode)
-          this.currentNode = nextNode
-        }
+        openTag(this.renderToken(tokens, i, options, env))
       } else if (type.match(/_close$/) && !hidden) {
-        this.currentNode = stack.pop()
+        closeTag()
       } else {
         let html
         if (type === "inline") {
           html = this.renderInline(token.children, options, env)
+        } else if (type === "html_inline") {
+          if (token.content.match(/^<\//)) {
+            closeTag()
+          } else {
+            openTag(rules[token.type](tokens, i, options, env, this))
+          }
         } else if (typeof rules[type] !== "undefined") {
           html = rules[token.type](tokens, i, options, env, this)
         }

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -12,6 +12,32 @@ describe("Rendering documents", () => {
       .to.have.selector("h1")
       .with.text.to.equal("Test")
   })
+
+  it("should render inline HTML", () => {
+    const input = unindent`
+      <i>Test</i>
+    `
+    const doc = new Document(input)
+    const html = doc.render()
+    expect(html)
+      .to.have.selector("i")
+      .with.text.to.equal("Test")
+  })
+
+  it("should render stacked inline HTML", () => {
+    const input = unindent`
+      <i>T<b>es</b>t</i>
+    `
+    const doc = new Document(input)
+    const html = doc.render()
+
+    expect(html)
+      .to.have.selector("i")
+      .with.text.to.equal("Test")
+    expect(html)
+      .to.have.selector("b")
+      .with.text.to.equal("es")
+  })
 })
 
 describe("Render hooks", () => {


### PR DESCRIPTION
Inline HTML didn’t get rendered properly.

Markdown:

    <i>Test</i>

Result before this fix:

    <i></i>Test

Result after this fix:

    <i>Test</i>