### PR TITLE
Fix parsing order

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -109,9 +109,14 @@ module.exports = class Config {
       let infoStringBefore = infoString
       this.infoStringParsers.forEach(parser => {
         infoString = infoString.replace(parser.regexp, (...matches) => {
-          keepGoing = true
-          parser.func.apply(target, matches)
-          return ""
+          const position = matches[matches.length - 2]
+          if (position === 0) {
+            keepGoing = true
+            parser.func.apply(target, matches)
+            return ""
+          } else {
+            return matches[0]
+          }
         })
       })
       if (infoString === infoStringBefore) {

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -27,6 +27,21 @@ describe("Info strings", () => {
     config.parseInfoString(infoString, fragment)
     expect(fragment.render()).to.have.selector('div[id="id1232124"]')
   })
+
+  it("should not mix up info strings", () => {
+    // This test makes sure the periods between 1 and 2 won’t call test1Func
+    const infoString = "+showmoretest=34..56 .testclass"
+    const config = new Config()
+    const test1Func = sinon.spy()
+    const test2Func = sinon.spy()
+    config.addInfoStringParser(/\..+/, test1Func)
+    config.addInfoStringCommand("showmoretest", { types: ["range"] }, test2Func)
+
+    config.parseInfoString(infoString, {})
+
+    expect(test2Func).to.have.been.calledWith("34..56")
+    expect(test1Func).to.have.been.calledWith(".testclass")
+  })
 })
 
 describe("Info string commands", () => {


### PR DESCRIPTION
Only match an info string parser when it matches the beginning of the
info string. Otherwise this info string:

    ```html +showmore=34..56 .testclass

Could match `.56` as CSS class.